### PR TITLE
0.1.1 - Refactored terminal, view -> appearance submenu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ set(BROWSER_SOURCES
 set(TERMINAL_SOURCES
     src/terminal/terminal_widget.h
     src/terminal/terminal_widget.cpp
+    src/terminal/pty_process.h
+    src/terminal/pty_process.cpp
 )
  
  # Search sources
@@ -127,6 +129,10 @@ add_executable(codeplace
 
 target_compile_options(codeplace PRIVATE -Wall -Wextra -Wpedantic)
 target_link_libraries(codeplace PRIVATE Qt6::Widgets Qt6::Core Qt6::Gui Qt6::Network Qt6::Concurrent)
+
+if(UNIX)
+    target_link_libraries(codeplace PRIVATE util)
+endif()
 
 # Deployment/Packaging
 if(TARGET codeplace)

--- a/src/core/default_shortcuts.h
+++ b/src/core/default_shortcuts.h
@@ -52,6 +52,7 @@ inline const QMap<QString, QString>& defaultShortcuts() {
         {"Delete",           "Delete"},
         {"Copy Path",        "Ctrl+Shift+C"},
         {"Reveal in Explorer", "Ctrl+Alt+R"},
+        {"Toggle Full Screen", "F11"},
     };
     return shortcuts;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
     app.setApplicationDisplayName("CodePlace Editor");
     app.setOrganizationName("CodePlace");
     app.setOrganizationDomain("https://codeplace.net");
-    app.setApplicationVersion("0.1.1-pre1");
+    app.setApplicationVersion("0.1.1-pre2");
     app.setWindowIcon(QIcon(":/resources/codeplace.png"));
 
     QCommandLineParser parser;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
     app.setApplicationDisplayName("CodePlace Editor");
     app.setOrganizationName("CodePlace");
     app.setOrganizationDomain("https://codeplace.net");
-    app.setApplicationVersion("0.1.0");
+    app.setApplicationVersion("0.1.1-pre1");
     app.setWindowIcon(QIcon(":/resources/codeplace.png"));
 
     QCommandLineParser parser;

--- a/src/main/main_window.cpp
+++ b/src/main/main_window.cpp
@@ -362,25 +362,21 @@ void MainWindow::createMenus() {
     toggleFileBrowserAction->setCheckable(true);
     toggleFileBrowserAction->setChecked(m_sidebarDock->isVisible());
     m_actionMap["Toggle File Browser"] = toggleFileBrowserAction;
-    connect(m_sidebarDock, &QDockWidget::visibilityChanged, toggleFileBrowserAction, &QAction::setChecked);
 
     auto *toggleSearchAction = appearanceSubMenu->addAction("S&earch", [this](bool checked) { m_searchDock->setVisible(checked); });
     toggleSearchAction->setCheckable(true);
     toggleSearchAction->setChecked(m_searchDock->isVisible());
     m_actionMap["Toggle Search"] = toggleSearchAction;
-    connect(m_searchDock, &QDockWidget::visibilityChanged, toggleSearchAction, &QAction::setChecked);
 
     auto *toggleOutlineAction = appearanceSubMenu->addAction("&Outline", [this](bool checked) { m_outlineDock->setVisible(checked); });
     toggleOutlineAction->setCheckable(true);
     toggleOutlineAction->setChecked(m_outlineDock->isVisible());
     m_actionMap["Toggle Outline"] = toggleOutlineAction;
-    connect(m_outlineDock, &QDockWidget::visibilityChanged, toggleOutlineAction, &QAction::setChecked);
 
     auto *toggleGitScmAction = appearanceSubMenu->addAction("Source &Control", [this](bool checked) { m_gitscmDock->setVisible(checked); });
     toggleGitScmAction->setCheckable(true);
     toggleGitScmAction->setChecked(m_gitscmDock->isVisible());
     m_actionMap["Toggle Source Control"] = toggleGitScmAction;
-    connect(m_gitscmDock, &QDockWidget::visibilityChanged, toggleGitScmAction, &QAction::setChecked);
 
     appearanceSubMenu->addSeparator();
 
@@ -388,13 +384,11 @@ void MainWindow::createMenus() {
     toggleTerminalAction->setCheckable(true);
     toggleTerminalAction->setChecked(m_terminalDock->isVisible());
     m_actionMap["Toggle Terminal"] = toggleTerminalAction;
-    connect(m_terminalDock, &QDockWidget::visibilityChanged, toggleTerminalAction, &QAction::setChecked);
 
     auto *toggleProblemsAction = appearanceSubMenu->addAction("&Problems", [this](bool checked) { m_problemsDock->setVisible(checked); });
     toggleProblemsAction->setCheckable(true);
     toggleProblemsAction->setChecked(m_problemsDock->isVisible());
     m_actionMap["Toggle Problems"] = toggleProblemsAction;
-    connect(m_problemsDock, &QDockWidget::visibilityChanged, toggleProblemsAction, &QAction::setChecked);
 
     appearanceSubMenu->addSeparator();
 
@@ -402,6 +396,17 @@ void MainWindow::createMenus() {
     toggleStatusBarAction->setCheckable(true);
     toggleStatusBarAction->setChecked(statusBar()->isVisible());
     m_actionMap["Toggle Status Bar"] = toggleStatusBarAction;
+
+    // Sync menu states before showing
+    connect(appearanceSubMenu, &QMenu::aboutToShow, [=]() {
+        toggleFileBrowserAction->setChecked(!m_sidebarDock->isHidden());
+        toggleSearchAction->setChecked(!m_searchDock->isHidden());
+        toggleOutlineAction->setChecked(!m_outlineDock->isHidden());
+        toggleGitScmAction->setChecked(!m_gitscmDock->isHidden());
+        toggleTerminalAction->setChecked(!m_terminalDock->isHidden());
+        toggleProblemsAction->setChecked(!m_problemsDock->isHidden());
+        toggleStatusBarAction->setChecked(statusBar()->isVisible());
+    });
 
     viewMenu->addSeparator();
 

--- a/src/main/main_window.cpp
+++ b/src/main/main_window.cpp
@@ -396,6 +396,13 @@ void MainWindow::createMenus() {
     m_actionMap["Toggle Problems"] = toggleProblemsAction;
     connect(m_problemsDock, &QDockWidget::visibilityChanged, toggleProblemsAction, &QAction::setChecked);
 
+    appearanceSubMenu->addSeparator();
+
+    auto *toggleStatusBarAction = appearanceSubMenu->addAction("&Status Bar", [this](bool checked) { statusBar()->setVisible(checked); });
+    toggleStatusBarAction->setCheckable(true);
+    toggleStatusBarAction->setChecked(statusBar()->isVisible());
+    m_actionMap["Toggle Status Bar"] = toggleStatusBarAction;
+
     viewMenu->addSeparator();
 
     auto *toggleLeftSidebarAction = viewMenu->addAction("Toggle Left Sidebar", [this](bool checked) {
@@ -471,6 +478,16 @@ void MainWindow::createMenus() {
     };
     connect(m_terminalDock, &QDockWidget::visibilityChanged, this, updateBottomPanelState);
     connect(m_problemsDock, &QDockWidget::visibilityChanged, this, updateBottomPanelState);
+
+    viewMenu->addSeparator();
+
+    auto *toggleFullScreenAction = viewMenu->addAction("&Full Screen", [this](bool checked) {
+        if (checked) showFullScreen();
+        else showNormal();
+    });
+    toggleFullScreenAction->setCheckable(true);
+    toggleFullScreenAction->setChecked(isFullScreen());
+    m_actionMap["Toggle Full Screen"] = toggleFullScreenAction;
     
     QMenu *helpMenu = menuBar()->addMenu("&Help");
     helpMenu->addAction("&About", [this]() {

--- a/src/main/main_window.cpp
+++ b/src/main/main_window.cpp
@@ -71,7 +71,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
         updateStatusBar();
     });
     
-    emit Core::ThemeManager::instance().themeChanged();
 }
 
 void MainWindow::setupLayout() {

--- a/src/terminal/pty_process.cpp
+++ b/src/terminal/pty_process.cpp
@@ -8,6 +8,7 @@
 #include <sys/ioctl.h>
 #include <signal.h>
 #include <errno.h>
+#include <stdlib.h>
 #endif
 
 #ifdef Q_OS_WIN
@@ -35,6 +36,9 @@ public:
         }
 
         if (pid == 0) { // Child
+            setenv("TERM", "xterm-256color", 1);
+            setenv("COLORTERM", "truecolor", 1);
+
             if (!workingDir.isEmpty()) {
                 if (chdir(workingDir.toLocal8Bit().constData()) != 0) {
                     perror("chdir failed");

--- a/src/terminal/pty_process.cpp
+++ b/src/terminal/pty_process.cpp
@@ -11,7 +11,10 @@
 #endif
 
 #ifdef Q_OS_WIN
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <thread>
+#include <atomic>
 #endif
 
 namespace Terminal {
@@ -116,15 +119,194 @@ private:
 #endif
 
 #ifdef Q_OS_WIN
+// Missing defines for some compilers/SDK versions
+#ifndef PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE
+#define PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE 0x00020016
+#endif
+
+typedef HRESULT (WINAPI *CreatePseudoConsolePtr)(COORD, HANDLE, HANDLE, DWORD, HPCON*);
+typedef HRESULT (WINAPI *ResizePseudoConsolePtr)(HPCON, COORD);
+typedef VOID (WINAPI *ClosePseudoConsolePtr)(HPCON);
+
 class WinPtyProcess : public PtyProcess {
-    // Basic stub for Windows until ConPTY integration
 public:
-    WinPtyProcess(QObject *parent) : PtyProcess(parent) {}
-    bool start(const QString &, const QStringList &, const QString &) override { return false; }
-    void stop() override {}
-    void write(const QByteArray &) override {}
-    bool isRunning() const override { return false; }
-    void resize(int, int) override {}
+    WinPtyProcess(QObject *parent) : PtyProcess(parent), 
+        m_hpc(nullptr), 
+        m_hInputWrite(INVALID_HANDLE_VALUE), 
+        m_hOutputRead(INVALID_HANDLE_VALUE),
+        m_hProcess(INVALID_HANDLE_VALUE) {}
+
+    ~WinPtyProcess() override { stop(); }
+
+    bool start(const QString &program, const QStringList &arguments, const QString &workingDir) override {
+        stop();
+        m_isStopping = false;
+
+        HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
+        auto pCreatePseudoConsole = (CreatePseudoConsolePtr)GetProcAddress(hKernel32, "CreatePseudoConsole");
+        if (!pCreatePseudoConsole) {
+            emit errorOccurred("ConPTY is not supported on this Windows version (requires Windows 10 1809+).");
+            return false;
+        }
+
+        HANDLE hInR, hInW, hOutR, hOutW;
+        
+        // Input pipe: child reads, parent writes
+        if (!CreatePipe(&hInR, &hInW, NULL, 0)) return false;
+        // Output pipe: child writes, parent reads
+        if (!CreatePipe(&hOutR, &hOutW, NULL, 0)) {
+            CloseHandle(hInR); CloseHandle(hInW);
+            return false;
+        }
+
+        m_hInputWrite = hInW;
+        m_hOutputRead = hOutR;
+
+        COORD size = { 80, 24 }; // Initial size
+        HRESULT hr = pCreatePseudoConsole(size, hInR, hOutW, 0, &m_hpc);
+        
+        // Close handles used by ConPTY in the child side
+        CloseHandle(hInR);
+        CloseHandle(hOutW);
+
+        if (FAILED(hr)) {
+            emit errorOccurred("Failed to create PseudoConsole: 0x" + QString::number(hr, 16));
+            return false;
+        }
+
+        // Setup process attributes
+        STARTUPINFOEXW siEx = { 0 };
+        siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
+        
+        SIZE_T attrListSize = 0;
+        InitializeProcThreadAttributeList(NULL, 1, 0, &attrListSize);
+        siEx.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)HeapAlloc(GetProcessHeap(), 0, attrListSize);
+        InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &attrListSize);
+        UpdateProcThreadAttribute(siEx.lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, m_hpc, sizeof(HPCON), NULL, NULL);
+
+        QString fullCmd = "\"" + program + "\"";
+        for (const QString &arg : arguments) {
+            QString escapedArg = arg;
+            escapedArg.replace("\"", "\\\"");
+            fullCmd += " \"" + escapedArg + "\"";
+        }
+        std::wstring wCmd = fullCmd.toStdWString();
+        std::wstring wDir = workingDir.toStdWString();
+
+        PROCESS_INFORMATION pi = { 0 };
+        BOOL success = CreateProcessW(
+            NULL, (LPWSTR)wCmd.c_str(), NULL, NULL, FALSE,
+            EXTENDED_STARTUPINFO_PRESENT, NULL, 
+            wDir.empty() ? NULL : wDir.c_str(), 
+            &siEx.StartupInfo, &pi
+        );
+
+        DeleteProcThreadAttributeList(siEx.lpAttributeList);
+        HeapFree(GetProcessHeap(), 0, siEx.lpAttributeList);
+
+        if (!success) {
+            emit errorOccurred("Failed to create process: " + QString::number(GetLastError()));
+            auto pClosePseudoConsole = (ClosePseudoConsolePtr)GetProcAddress(hKernel32, "ClosePseudoConsole");
+            if (pClosePseudoConsole) pClosePseudoConsole(m_hpc);
+            m_hpc = nullptr;
+            return false;
+        }
+
+        m_hProcess = pi.hProcess;
+        CloseHandle(pi.hThread);
+
+        m_readThread = std::thread([this]() {
+            char buffer[4096];
+            DWORD bytesRead;
+            while (!m_isStopping) {
+                if (ReadFile(m_hOutputRead, buffer, sizeof(buffer), &bytesRead, NULL) && bytesRead > 0) {
+                    QByteArray data(buffer, bytesRead);
+                    QMetaObject::invokeMethod(this, [this, data]() {
+                        emit readyRead(data);
+                    }, Qt::QueuedConnection);
+                } else {
+                    break;
+                }
+            }
+            
+            if (!m_isStopping) {
+                DWORD exitCode = 0;
+                GetExitCodeProcess(m_hProcess, &exitCode);
+                QMetaObject::invokeMethod(this, [this, exitCode]() {
+                    stop();
+                    emit finished(exitCode);
+                }, Qt::QueuedConnection);
+            }
+        });
+
+        return true;
+    }
+
+    void stop() override {
+        if (!isRunning()) return;
+
+        m_isStopping = true;
+        
+        if (m_hProcess != INVALID_HANDLE_VALUE) {
+            TerminateProcess(m_hProcess, 1);
+            CloseHandle(m_hProcess);
+            m_hProcess = INVALID_HANDLE_VALUE;
+        }
+
+        if (m_hpc) {
+            auto pClosePseudoConsole = (ClosePseudoConsolePtr)GetProcAddress(GetModuleHandleW(L"kernel32.dll"), "ClosePseudoConsole");
+            if (pClosePseudoConsole) pClosePseudoConsole(m_hpc);
+            m_hpc = nullptr;
+        }
+
+        if (m_hInputWrite != INVALID_HANDLE_VALUE) {
+            CloseHandle(m_hInputWrite);
+            m_hInputWrite = INVALID_HANDLE_VALUE;
+        }
+
+        if (m_hOutputRead != INVALID_HANDLE_VALUE) {
+            CloseHandle(m_hOutputRead);
+            m_hOutputRead = INVALID_HANDLE_VALUE;
+        }
+
+        if (m_readThread.joinable()) {
+            m_readThread.join();
+        }
+
+        emit finished(0);
+    }
+
+    void write(const QByteArray &data) override {
+        if (m_hInputWrite != INVALID_HANDLE_VALUE) {
+            DWORD written;
+            WriteFile(m_hInputWrite, data.constData(), data.size(), &written, NULL);
+        }
+    }
+
+    bool isRunning() const override {
+        if (m_hProcess == INVALID_HANDLE_VALUE) return false;
+        DWORD exitCode;
+        if (GetExitCodeProcess(m_hProcess, &exitCode)) {
+            return exitCode == STILL_ACTIVE;
+        }
+        return false;
+    }
+
+    void resize(int cols, int rows) override {
+        if (m_hpc) {
+            COORD size = { (SHORT)cols, (SHORT)rows };
+            auto pResizePseudoConsole = (ResizePseudoConsolePtr)GetProcAddress(GetModuleHandleW(L"kernel32.dll"), "ResizePseudoConsole");
+            if (pResizePseudoConsole) pResizePseudoConsole(m_hpc, size);
+        }
+    }
+
+private:
+    HPCON m_hpc;
+    HANDLE m_hInputWrite;
+    HANDLE m_hOutputRead;
+    HANDLE m_hProcess;
+    std::thread m_readThread;
+    std::atomic<bool> m_isStopping{false};
 };
 #endif
 

--- a/src/terminal/pty_process.cpp
+++ b/src/terminal/pty_process.cpp
@@ -1,0 +1,144 @@
+#include "pty_process.h"
+#include <QSocketNotifier>
+#include <QDebug>
+
+#ifdef Q_OS_UNIX
+#include <pty.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <signal.h>
+#include <errno.h>
+#endif
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
+namespace Terminal {
+
+#ifdef Q_OS_UNIX
+class UnixPtyProcess : public PtyProcess {
+public:
+    UnixPtyProcess(QObject *parent) : PtyProcess(parent), m_masterFd(-1), m_pid(-1), m_notifier(nullptr) {}
+    ~UnixPtyProcess() override { stop(); }
+
+    bool start(const QString &program, const QStringList &arguments, const QString &workingDir) override {
+        int master;
+        pid_t pid = forkpty(&master, nullptr, nullptr, nullptr);
+
+        if (pid < 0) {
+            emit errorOccurred("Failed to fork PTY: " + QString::fromLocal8Bit(strerror(errno)));
+            return false;
+        }
+
+        if (pid == 0) { // Child
+            if (!workingDir.isEmpty()) {
+                if (chdir(workingDir.toLocal8Bit().constData()) != 0) {
+                    perror("chdir failed");
+                }
+            }
+
+            QByteArray prog = program.toLocal8Bit();
+            QVector<QByteArray> argStorage;
+            QVector<char*> argv;
+            
+            argv.push_back(prog.data());
+            for (const QString &arg : arguments) {
+                argStorage.push_back(arg.toLocal8Bit());
+                argv.push_back(argStorage.last().data());
+            }
+            argv.push_back(nullptr);
+
+            execvp(prog.constData(), argv.data());
+            _exit(1);
+        }
+
+        // Parent
+        m_masterFd = master;
+        m_pid = pid;
+
+        m_notifier = new QSocketNotifier(m_masterFd, QSocketNotifier::Read, this);
+        connect(m_notifier, &QSocketNotifier::activated, this, [this](int) {
+            char buffer[4096];
+            ssize_t bytes = read(m_masterFd, buffer, sizeof(buffer));
+            if (bytes > 0) {
+                emit readyRead(QByteArray(buffer, bytes));
+            } else if (bytes < 0 && (errno == EINTR || errno == EAGAIN)) {
+                return;
+            } else {
+                stop();
+            }
+        });
+
+        return true;
+    }
+
+    void stop() override {
+        if (m_pid > 0) {
+            kill(m_pid, SIGHUP);
+            m_pid = -1;
+        }
+        if (m_masterFd != -1) {
+            delete m_notifier;
+            m_notifier = nullptr;
+            close(m_masterFd);
+            m_masterFd = -1;
+            emit finished(0);
+        }
+    }
+
+    void write(const QByteArray &data) override {
+        if (m_masterFd != -1) {
+            ::write(m_masterFd, data.constData(), data.size());
+        }
+    }
+
+    bool isRunning() const override {
+        return m_pid > 0;
+    }
+
+    void resize(int cols, int rows) override {
+        if (m_masterFd != -1) {
+            struct winsize ws;
+            ws.ws_col = cols;
+            ws.ws_row = rows;
+            ws.ws_xpixel = 0;
+            ws.ws_ypixel = 0;
+            ioctl(m_masterFd, TIOCSWINSZ, &ws);
+        }
+    }
+
+private:
+    int m_masterFd;
+    pid_t m_pid;
+    QSocketNotifier *m_notifier;
+};
+#endif
+
+#ifdef Q_OS_WIN
+class WinPtyProcess : public PtyProcess {
+    // Basic stub for Windows until ConPTY integration
+public:
+    WinPtyProcess(QObject *parent) : PtyProcess(parent) {}
+    bool start(const QString &, const QStringList &, const QString &) override { return false; }
+    void stop() override {}
+    void write(const QByteArray &) override {}
+    bool isRunning() const override { return false; }
+    void resize(int, int) override {}
+};
+#endif
+
+PtyProcess::PtyProcess(QObject *parent) : QObject(parent) {}
+PtyProcess::~PtyProcess() {}
+
+PtyProcess* PtyProcess::create(QObject *parent) {
+#ifdef Q_OS_UNIX
+    return new UnixPtyProcess(parent);
+#elif defined(Q_OS_WIN)
+    return new WinPtyProcess(parent);
+#else
+    return nullptr;
+#endif
+}
+
+} // namespace Terminal

--- a/src/terminal/pty_process.h
+++ b/src/terminal/pty_process.h
@@ -1,0 +1,34 @@
+#ifndef PTY_PROCESS_H
+#define PTY_PROCESS_H
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QSize>
+
+namespace Terminal {
+
+class PtyProcess : public QObject {
+    Q_OBJECT
+
+public:
+    explicit PtyProcess(QObject *parent = nullptr);
+    virtual ~PtyProcess();
+
+    virtual bool start(const QString &program, const QStringList &arguments, const QString &workingDir = QString()) = 0;
+    virtual void stop() = 0;
+    virtual void write(const QByteArray &data) = 0;
+    virtual bool isRunning() const = 0;
+    virtual void resize(int cols, int rows) = 0;
+
+    static PtyProcess* create(QObject *parent = nullptr);
+
+signals:
+    void readyRead(const QByteArray &data);
+    void finished(int exitCode);
+    void errorOccurred(const QString &error);
+};
+
+} // namespace Terminal
+
+#endif // PTY_PROCESS_H

--- a/src/terminal/terminal_widget.cpp
+++ b/src/terminal/terminal_widget.cpp
@@ -11,6 +11,8 @@
 
 #include <signal.h>
 #include <unistd.h>
+#include <QMimeData>
+#include "pty_process.h"
 
 namespace Terminal {
 
@@ -19,48 +21,38 @@ TerminalWidget::TerminalWidget(QWidget *parent, const QString &workingDirectory)
     
     m_shell = detectShell();
     
-    
     m_restartButton = new QPushButton("New Terminal Session?", this);
     m_restartButton->hide();
     connect(m_restartButton, &QPushButton::clicked, this, &TerminalWidget::restartShell);
 
-    
-    setReadOnly(false);
+    setReadOnly(true); // Terminal is read-only to prevent ad-hoc editing
     setLineWrapMode(QPlainTextEdit::NoWrap);
     
     updateTheme();
     connect(&Core::ThemeManager::instance(), &Core::ThemeManager::themeChanged, this, &TerminalWidget::updateTheme);
     
-    m_process = new QProcess(this);
-    if (!workingDirectory.isEmpty()) {
-        m_process->setWorkingDirectory(workingDirectory);
-    }
+    m_pty = PtyProcess::create(this);
     
-    connect(m_process, &QProcess::readyReadStandardOutput, this, &TerminalWidget::onReadyReadStandardOutput);
-    connect(m_process, &QProcess::readyReadStandardError, this, &TerminalWidget::onReadyReadStandardError);
-    connect(m_process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &TerminalWidget::onProcessFinished);
+    connect(m_pty, &PtyProcess::readyRead, this, &TerminalWidget::processData);
+    connect(m_pty, &PtyProcess::finished, this, &TerminalWidget::onProcessFinished);
+    connect(m_pty, &PtyProcess::errorOccurred, this, [this](const QString &err) {
+        appendPlainText("Error: " + err);
+    });
     
     connect(&Core::ProjectManager::instance(), &Core::ProjectManager::projectRootChanged,
             this, &TerminalWidget::setWorkingDirectory);
 
     QStringList args;
-    if (m_shell.contains("bash") || m_shell.contains("zsh")) {
-        args << "-i";
-    }
-
-    m_process->start(m_shell, args);
-    if (!m_process->waitForStarted()) {
+    // Shell will be interactive naturally due to PTY, -i is often redundant and can cause duplicate prompts
+    
+    if (!m_pty->start(m_shell, args, m_workingDirectory)) {
         appendPlainText("Error: Could not start shell: " + m_shell);
     }
 }
 
 TerminalWidget::~TerminalWidget() {
-    if (m_process->state() != QProcess::NotRunning) {
-        ::kill(m_process->processId(), SIGHUP);
-        m_process->terminate();
-        if (!m_process->waitForFinished(1000)) {
-            m_process->kill();
-        }
+    if (m_pty) {
+        m_pty->stop();
     }
 }
 
@@ -69,18 +61,12 @@ void TerminalWidget::setWorkingDirectory(const QString &dir) {
 }
 
 void TerminalWidget::sendInput(const QString &input) {
-    if (m_process->state() == QProcess::Running) {
-        m_process->write(input.toUtf8());
+    if (m_pty && m_pty->isRunning()) {
+        m_pty->write(input.toUtf8());
     }
 }
 
-void TerminalWidget::onReadyReadStandardOutput() {
-    processData(m_process->readAllStandardOutput());
-}
-
-void TerminalWidget::onReadyReadStandardError() {
-    processData(m_process->readAllStandardError());
-}
+// Redundant readyRead slots removed, processData is now connected directly to PtyProcess::readyRead
 
 void TerminalWidget::processData(const QByteArray &data) {
     m_ansiBuffer.append(data);
@@ -267,7 +253,7 @@ QString TerminalWidget::detectShell() {
     return "/bin/bash";
 }
 
-void TerminalWidget::onProcessFinished(int exitCode, QProcess::ExitStatus ) {
+void TerminalWidget::onProcessFinished(int exitCode) {
     appendPlainText(QString("\nProcess finished with exit code %1").arg(exitCode));
     
     
@@ -283,20 +269,13 @@ void TerminalWidget::restartShell() {
     clear();
     m_ansiBuffer.clear();
     
-    if (m_process->state() != QProcess::NotRunning) {
-        m_process->kill();
+    if (m_pty) {
+        m_pty->stop();
     }
     
     QStringList args;
-    if (m_shell.contains("bash") || m_shell.contains("zsh")) {
-        args << "-i";
-    }
-
-    if (!m_workingDirectory.isEmpty()) {
-        m_process->setWorkingDirectory(m_workingDirectory);
-    }
     
-    m_process->start(m_shell, args);
+    m_pty->start(m_shell, args, m_workingDirectory);
 }
 
 void TerminalWidget::resizeEvent(QResizeEvent *event) {
@@ -305,6 +284,23 @@ void TerminalWidget::resizeEvent(QResizeEvent *event) {
         m_restartButton->move((width() - m_restartButton->width()) / 2, 
                              (height() - m_restartButton->height()) / 2);
     }
+
+    // Notify PTY of size change
+    if (m_pty && m_pty->isRunning()) {
+        QFontMetrics fm(font());
+        int charWidth = fm.horizontalAdvance('W');
+        int charHeight = fm.height();
+        
+        if (charWidth > 0 && charHeight > 0) {
+            int cols = viewport()->width() / charWidth;
+            int rows = viewport()->height() / charHeight;
+            if (cols != m_lastCols || rows != m_lastRows) {
+                m_lastCols = cols;
+                m_lastRows = rows;
+                m_pty->resize(cols, rows);
+            }
+        }
+    }
 }
 
 bool TerminalWidget::event(QEvent *event) {
@@ -312,8 +308,7 @@ bool TerminalWidget::event(QEvent *event) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent*>(event);
         if (keyEvent->modifiers() & Qt::ControlModifier) {
             int key = keyEvent->key();
-            
-            
+            // Allow Ctrl+C, Ctrl+V, etc. to be handled here instead of as shortcuts
             if (key >= Qt::Key_A && key <= Qt::Key_Z) {
                 event->accept();
                 return true;
@@ -323,28 +318,27 @@ bool TerminalWidget::event(QEvent *event) {
     return QPlainTextEdit::event(event);
 }
 
+void TerminalWidget::focusInEvent(QFocusEvent *event) {
+    QPlainTextEdit::focusInEvent(event);
+    // Ensure cursor is always at the end when gaining focus
+    QTextCursor cursor = textCursor();
+    cursor.movePosition(QTextCursor::End);
+    setTextCursor(cursor);
+}
+
+void TerminalWidget::insertFromMimeData(const QMimeData *source) {
+    if (source->hasText()) {
+        sendInput(source->text());
+    }
+}
+
 void TerminalWidget::keyPressEvent(QKeyEvent *event) {
     if (event->modifiers() & Qt::ControlModifier) {
         int key = event->key();
 
-        
         if (key == Qt::Key_C && textCursor().hasSelection()) {
             copy();
             return;
-        }
-
-        
-        if (key == Qt::Key_C && !textCursor().hasSelection()) {
-            if (m_process->state() == QProcess::Running) {
-                
-                QTextCursor cursor = textCursor();
-                cursor.movePosition(QTextCursor::End);
-                cursor.insertText("^C\n");
-                verticalScrollBar()->setValue(verticalScrollBar()->maximum());
-                
-                ::kill(m_process->processId(), SIGINT);
-                return;
-            }
         }
 
         if (key == Qt::Key_V) {
@@ -354,7 +348,7 @@ void TerminalWidget::keyPressEvent(QKeyEvent *event) {
 
         if (key >= Qt::Key_A && key <= Qt::Key_Z) {
             char ctrlChar = static_cast<char>(key - Qt::Key_A + 1);
-            sendInput(QString(ctrlChar));
+            sendInput(QByteArray(1, ctrlChar));
             return;
         }
     }
@@ -362,16 +356,23 @@ void TerminalWidget::keyPressEvent(QKeyEvent *event) {
     if (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) {
         sendInput("\n");
     } else if (event->key() == Qt::Key_Backspace) {
-        sendInput("\b");
+        sendInput("\x7f"); // Sending DEL which is standard for most modern terminals
     } else if (event->key() == Qt::Key_Tab) {
         sendInput("\t");
+    } else if (event->key() == Qt::Key_Left) {
+        sendInput("\x1B[D");
+    } else if (event->key() == Qt::Key_Right) {
+        sendInput("\x1B[C");
+    } else if (event->key() == Qt::Key_Up) {
+        sendInput("\x1B[A");
+    } else if (event->key() == Qt::Key_Down) {
+        sendInput("\x1B[B");
     } else {
         QString text = event->text();
         if (!text.isEmpty()) {
             sendInput(text);
         }
     }
-    
 }
 
 } 

--- a/src/terminal/terminal_widget.cpp
+++ b/src/terminal/terminal_widget.cpp
@@ -295,9 +295,19 @@ void TerminalWidget::updateTheme() {
 }
 
 QString TerminalWidget::detectShell() {
+#ifdef Q_OS_WIN
+    char* comspec = getenv("COMSPEC");
+    if (comspec) return QString::fromLocal8Bit(comspec);
+    return "cmd.exe";
+#else
     char* shell = getenv("SHELL");
     if (shell) return QString::fromLocal8Bit(shell);
+#ifdef Q_OS_MAC
+    return "/bin/zsh";
+#else
     return "/bin/bash";
+#endif
+#endif
 }
 
 void TerminalWidget::onProcessFinished(int exitCode) {

--- a/src/terminal/terminal_widget.cpp
+++ b/src/terminal/terminal_widget.cpp
@@ -370,15 +370,8 @@ void TerminalWidget::resizeEvent(QResizeEvent *event) {
 
 bool TerminalWidget::event(QEvent *event) {
     if (event->type() == QEvent::ShortcutOverride) {
-        QKeyEvent *keyEvent = static_cast<QKeyEvent*>(event);
-        if (keyEvent->modifiers() & Qt::ControlModifier) {
-            int key = keyEvent->key();
-            // Allow Ctrl+C, Ctrl+V, etc. to be handled here instead of as shortcuts
-            if (key >= Qt::Key_A && key <= Qt::Key_Z) {
-                event->accept();
-                return true;
-            }
-        }
+        event->accept();
+        return true;
     }
     return QPlainTextEdit::event(event);
 }
@@ -419,7 +412,7 @@ void TerminalWidget::keyPressEvent(QKeyEvent *event) {
     }
 
     if (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) {
-        sendInput("\n");
+        sendInput("\r");
     } else if (event->key() == Qt::Key_Backspace) {
         sendInput("\x7f"); // Sending DEL which is standard for most modern terminals
     } else if (event->key() == Qt::Key_Tab) {
@@ -438,7 +431,7 @@ void TerminalWidget::keyPressEvent(QKeyEvent *event) {
             sendInput(text);
         }
     }
-    event->accept(); // Prevent base class from inserting text
+    event->accept();
 }
 
 } 

--- a/src/terminal/terminal_widget.cpp
+++ b/src/terminal/terminal_widget.cpp
@@ -8,6 +8,7 @@
 #include <QRegularExpression>
 #include <QPushButton>
 #include <QVBoxLayout>
+#include <QDir>
 
 #include <signal.h>
 #include <unistd.h>
@@ -20,7 +21,9 @@ TerminalWidget::TerminalWidget(QWidget *parent, const QString &workingDirectory)
     : QPlainTextEdit(parent), m_workingDirectory(workingDirectory) {
     
     if (m_workingDirectory.isEmpty()) {
-        m_workingDirectory = Core::ProjectManager::instance().projectRoot();
+        m_workingDirectory = QDir::cleanPath(Core::ProjectManager::instance().projectRoot());
+    } else {
+        m_workingDirectory = QDir::cleanPath(m_workingDirectory);
     }
     
     m_shell = detectShell();
@@ -66,14 +69,16 @@ TerminalWidget::~TerminalWidget() {
 }
 
 void TerminalWidget::setWorkingDirectory(const QString &dir) {
-    if (m_workingDirectory == dir) return;
-    m_workingDirectory = dir;
+    QString cleanDir = QDir::cleanPath(dir);
+    if (m_workingDirectory == cleanDir) return;
+    m_workingDirectory = cleanDir;
 
     if (m_pty && m_pty->isRunning()) {
+        // Use a leading space to prevent the command from being recorded in shell history
 #ifdef Q_OS_WIN
-        sendInput(QString("cd /d \"%1\"\r\n").arg(m_workingDirectory));
+        sendInput(QString(" cd /d \"%1\"\r\n").arg(m_workingDirectory));
 #else
-        sendInput(QString("cd \"%1\"\n").arg(m_workingDirectory));
+        sendInput(QString(" cd \"%1\"\n").arg(m_workingDirectory));
 #endif
     }
 }
@@ -378,7 +383,15 @@ bool TerminalWidget::event(QEvent *event) {
 
 void TerminalWidget::focusInEvent(QFocusEvent *event) {
     QPlainTextEdit::focusInEvent(event);
-    // Ensure cursor is always at the end when gaining focus
+    moveCursorToEnd();
+}
+
+void TerminalWidget::mousePressEvent(QMouseEvent *event) {
+    QPlainTextEdit::mousePressEvent(event);
+    moveCursorToEnd();
+}
+
+void TerminalWidget::moveCursorToEnd() {
     QTextCursor cursor = textCursor();
     cursor.movePosition(QTextCursor::End);
     setTextCursor(cursor);

--- a/src/terminal/terminal_widget.cpp
+++ b/src/terminal/terminal_widget.cpp
@@ -29,7 +29,9 @@ TerminalWidget::TerminalWidget(QWidget *parent, const QString &workingDirectory)
     m_restartButton->hide();
     connect(m_restartButton, &QPushButton::clicked, this, &TerminalWidget::restartShell);
 
-    setReadOnly(true); // Terminal is read-only to prevent ad-hoc editing
+    setReadOnly(false); // Set to false to allow blinking cursor; input is manually intercepted
+    setUndoRedoEnabled(false);
+    setCursorWidth(2); 
     setLineWrapMode(QPlainTextEdit::NoWrap);
     
     updateTheme();
@@ -436,6 +438,7 @@ void TerminalWidget::keyPressEvent(QKeyEvent *event) {
             sendInput(text);
         }
     }
+    event->accept(); // Prevent base class from inserting text
 }
 
 } 

--- a/src/terminal/terminal_widget.cpp
+++ b/src/terminal/terminal_widget.cpp
@@ -71,7 +71,7 @@ void TerminalWidget::sendInput(const QString &input) {
 void TerminalWidget::processData(const QByteArray &data) {
     m_ansiBuffer.append(data);
     
-    QTextCursor cursor = textCursor();
+    QTextCursor cursor(document());
     cursor.movePosition(QTextCursor::End);
     
     QTextCharFormat defaultFormat;
@@ -85,8 +85,6 @@ void TerminalWidget::processData(const QByteArray &data) {
         char c = m_ansiBuffer[i];
         
         if (c == '\x1B') { 
-            
-            
             int end = -1;
             if (i + 1 < m_ansiBuffer.size()) {
                 char next = m_ansiBuffer[i + 1];
@@ -115,17 +113,13 @@ void TerminalWidget::processData(const QByteArray &data) {
             }
             
             if (end != -1) {
-                
                 if (i > lastProcessed) {
                     QString text = QString::fromUtf8(m_ansiBuffer.mid(lastProcessed, i - lastProcessed));
-                    text.remove('\r');
                     cursor.insertText(text, currentFormat);
                 }
                 
-                
                 QByteArray seq = m_ansiBuffer.mid(i, end - i + 1);
                 if (seq.startsWith("\x1B[") && seq.endsWith("m")) {
-                    
                     QString params = QString::fromLatin1(seq.mid(2, seq.size() - 3));
                     for (const QString &p : params.split(';')) {
                         int val = p.toInt();
@@ -149,36 +143,47 @@ void TerminalWidget::processData(const QByteArray &data) {
                             currentFormat.setForeground(Core::ThemeManager::instance().getColor(colors[val - 90]));
                         }
                     }
+                } else if (seq == "\x1B[K" || seq == "\x1B[0K") {
+                    cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
+                    cursor.removeSelectedText();
+                } else if (seq == "\x1B[2K") {
+                    cursor.movePosition(QTextCursor::StartOfBlock);
+                    cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
+                    cursor.removeSelectedText();
+                } else if (seq == "\x1B[H" || seq == "\x1B[1;1H") {
+                    // Very basic home handling
+                    cursor.movePosition(QTextCursor::Start);
                 }
                 
                 i = end;
                 lastProcessed = i + 1;
             } else {
-                
                 break;
             }
+        } else if (c == '\r') {
+            if (i > lastProcessed) {
+                QString text = QString::fromUtf8(m_ansiBuffer.mid(lastProcessed, i - lastProcessed));
+                cursor.insertText(text, currentFormat);
+            }
+            cursor.movePosition(QTextCursor::StartOfBlock);
+            lastProcessed = i + 1;
         } else if (c == '\x08') { 
             if (i > lastProcessed) {
                 QString text = QString::fromUtf8(m_ansiBuffer.mid(lastProcessed, i - lastProcessed));
-                text.remove('\r');
                 cursor.insertText(text, currentFormat);
             }
             cursor.deletePreviousChar();
             lastProcessed = i + 1;
         } else if (static_cast<unsigned char>(c) < 32 && c != '\n' && c != '\r' && c != '\t') {
-            
             if (i > lastProcessed) {
                 QString text = QString::fromUtf8(m_ansiBuffer.mid(lastProcessed, i - lastProcessed));
-                text.remove('\r');
                 cursor.insertText(text, currentFormat);
             }
             lastProcessed = i + 1;
         }
     }
     
-    
     if (lastProcessed < m_ansiBuffer.size()) {
-        
         bool inPartialEsc = false;
         for (int k = m_ansiBuffer.size() - 1; k >= lastProcessed; --k) {
             if (m_ansiBuffer[k] == '\x1B') {
@@ -189,11 +194,9 @@ void TerminalWidget::processData(const QByteArray &data) {
         
         if (!inPartialEsc) {
             QString text = QString::fromUtf8(m_ansiBuffer.mid(lastProcessed));
-            text.remove('\r');
             cursor.insertText(text, currentFormat);
             m_ansiBuffer.clear();
         } else {
-            
             m_ansiBuffer = m_ansiBuffer.mid(lastProcessed);
         }
     } else {

--- a/src/terminal/terminal_widget.cpp
+++ b/src/terminal/terminal_widget.cpp
@@ -72,19 +72,47 @@ void TerminalWidget::processData(const QByteArray &data) {
     m_ansiBuffer.append(data);
     
     QTextCursor cursor(document());
-    cursor.movePosition(QTextCursor::End);
     
-    QTextCharFormat defaultFormat;
-    defaultFormat.setForeground(Core::ThemeManager::instance().getColor(Core::ThemeManager::EditorForeground));
+    static const QTextCharFormat defaultFormat = []() {
+        QTextCharFormat fmt;
+        return fmt;
+    }();
     
-    QTextCharFormat currentFormat = cursor.charFormat();
-    if (currentFormat.isEmpty()) currentFormat = defaultFormat;
+    QTextCharFormat currentFormat = textCursor().charFormat();
+    if (currentFormat.isEmpty()) {
+        currentFormat.setForeground(Core::ThemeManager::instance().getColor(Core::ThemeManager::EditorForeground));
+    }
+    
+    auto flushText = [&](int start, int end) {
+        if (end <= start) return;
+        QString text = QString::fromUtf8(m_ansiBuffer.mid(start, end - start));
+        
+        for (QChar c : text) {
+            if (c == '\n') {
+                cursor.movePosition(QTextCursor::End);
+                cursor.insertText("\n", currentFormat);
+                cursor.movePosition(QTextCursor::End);
+            } else if (c == '\t') {
+                cursor.insertText("    ", currentFormat);
+            } else {
+                // Overwrite logic: if not at end of line, replace next char
+                if (!cursor.atBlockEnd()) {
+                    cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor);
+                }
+                cursor.insertText(c, currentFormat);
+            }
+        }
+    };
 
     int lastProcessed = 0;
+    cursor = textCursor();
+
     for (int i = 0; i < m_ansiBuffer.size(); ++i) {
-        char c = m_ansiBuffer[i];
+        unsigned char c = static_cast<unsigned char>(m_ansiBuffer[i]);
         
         if (c == '\x1B') { 
+            
+            
             int end = -1;
             if (i + 1 < m_ansiBuffer.size()) {
                 char next = m_ansiBuffer[i + 1];
@@ -113,43 +141,50 @@ void TerminalWidget::processData(const QByteArray &data) {
             }
             
             if (end != -1) {
-                if (i > lastProcessed) {
-                    QString text = QString::fromUtf8(m_ansiBuffer.mid(lastProcessed, i - lastProcessed));
-                    cursor.insertText(text, currentFormat);
-                }
+                flushText(lastProcessed, i);
                 
                 QByteArray seq = m_ansiBuffer.mid(i, end - i + 1);
                 if (seq.startsWith("\x1B[") && seq.endsWith("m")) {
+                    
                     QString params = QString::fromLatin1(seq.mid(2, seq.size() - 3));
-                    for (const QString &p : params.split(';')) {
-                        int val = p.toInt();
-                        if (val == 0) currentFormat = defaultFormat;
-                        else if (val == 1) currentFormat.setFontWeight(QFont::Bold);
-                        else if (val >= 30 && val <= 37) {
-                            static const Core::ThemeManager::EditorColor colors[] = { 
-                                Core::ThemeManager::TerminalBlack, Core::ThemeManager::TerminalRed, 
-                                Core::ThemeManager::TerminalGreen, Core::ThemeManager::TerminalYellow, 
-                                Core::ThemeManager::TerminalBlue, Core::ThemeManager::TerminalMagenta, 
-                                Core::ThemeManager::TerminalCyan, Core::ThemeManager::TerminalWhite 
-                            };
-                            currentFormat.setForeground(Core::ThemeManager::instance().getColor(colors[val - 30]));
-                        } else if (val >= 90 && val <= 97) {
-                            static const Core::ThemeManager::EditorColor colors[] = { 
-                                Core::ThemeManager::TerminalBrightBlack, Core::ThemeManager::TerminalBrightRed, 
-                                Core::ThemeManager::TerminalBrightGreen, Core::ThemeManager::TerminalBrightYellow, 
-                                Core::ThemeManager::TerminalBrightBlue, Core::ThemeManager::TerminalBrightMagenta, 
-                                Core::ThemeManager::TerminalBrightCyan, Core::ThemeManager::TerminalBrightWhite 
-                            };
-                            currentFormat.setForeground(Core::ThemeManager::instance().getColor(colors[val - 90]));
+                    if (params.isEmpty() || params == "0") {
+                        currentFormat = defaultFormat;
+                        currentFormat.setForeground(Core::ThemeManager::instance().getColor(Core::ThemeManager::EditorForeground));
+                    } else {
+                        for (const QString &p : params.split(';')) {
+                            int val = p.toInt();
+                            if (val == 0) {
+                                currentFormat = defaultFormat;
+                                currentFormat.setForeground(Core::ThemeManager::instance().getColor(Core::ThemeManager::EditorForeground));
+                            } else if (val == 1) currentFormat.setFontWeight(QFont::Bold);
+                            else if (val >= 30 && val <= 37) {
+                                static const Core::ThemeManager::EditorColor colors[] = { 
+                                    Core::ThemeManager::TerminalBlack, Core::ThemeManager::TerminalRed, 
+                                    Core::ThemeManager::TerminalGreen, Core::ThemeManager::TerminalYellow, 
+                                    Core::ThemeManager::TerminalBlue, Core::ThemeManager::TerminalMagenta, 
+                                    Core::ThemeManager::TerminalCyan, Core::ThemeManager::TerminalWhite 
+                                };
+                                currentFormat.setForeground(Core::ThemeManager::instance().getColor(colors[val - 30]));
+                            } else if (val >= 90 && val <= 97) {
+                                static const Core::ThemeManager::EditorColor colors[] = { 
+                                    Core::ThemeManager::TerminalBrightBlack, Core::ThemeManager::TerminalBrightRed, 
+                                    Core::ThemeManager::TerminalBrightGreen, Core::ThemeManager::TerminalBrightYellow, 
+                                    Core::ThemeManager::TerminalBrightBlue, Core::ThemeManager::TerminalBrightMagenta, 
+                                    Core::ThemeManager::TerminalBrightCyan, Core::ThemeManager::TerminalBrightWhite 
+                                };
+                                currentFormat.setForeground(Core::ThemeManager::instance().getColor(colors[val - 90]));
+                            }
                         }
                     }
                 } else if (seq == "\x1B[K" || seq == "\x1B[0K") {
-                    cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
-                    cursor.removeSelectedText();
+                    QTextCursor temp = cursor;
+                    temp.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
+                    temp.removeSelectedText();
                 } else if (seq == "\x1B[2K") {
-                    cursor.movePosition(QTextCursor::StartOfBlock);
-                    cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
-                    cursor.removeSelectedText();
+                    QTextCursor temp = cursor;
+                    temp.movePosition(QTextCursor::StartOfBlock);
+                    temp.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
+                    temp.removeSelectedText();
                 } else if (seq == "\x1B[H" || seq == "\x1B[1;1H") {
                     // Very basic home handling
                     cursor.movePosition(QTextCursor::Start);
@@ -158,32 +193,26 @@ void TerminalWidget::processData(const QByteArray &data) {
                 i = end;
                 lastProcessed = i + 1;
             } else {
+                
                 break;
             }
         } else if (c == '\r') {
-            if (i > lastProcessed) {
-                QString text = QString::fromUtf8(m_ansiBuffer.mid(lastProcessed, i - lastProcessed));
-                cursor.insertText(text, currentFormat);
-            }
+            flushText(lastProcessed, i);
             cursor.movePosition(QTextCursor::StartOfBlock);
             lastProcessed = i + 1;
         } else if (c == '\x08') { 
-            if (i > lastProcessed) {
-                QString text = QString::fromUtf8(m_ansiBuffer.mid(lastProcessed, i - lastProcessed));
-                cursor.insertText(text, currentFormat);
-            }
+            flushText(lastProcessed, i);
             cursor.deletePreviousChar();
             lastProcessed = i + 1;
-        } else if (static_cast<unsigned char>(c) < 32 && c != '\n' && c != '\r' && c != '\t') {
-            if (i > lastProcessed) {
-                QString text = QString::fromUtf8(m_ansiBuffer.mid(lastProcessed, i - lastProcessed));
-                cursor.insertText(text, currentFormat);
-            }
+        } else if (c < 32 && c != '\n' && c != '\t') {
+            flushText(lastProcessed, i);
             lastProcessed = i + 1;
         }
     }
     
+    
     if (lastProcessed < m_ansiBuffer.size()) {
+        
         bool inPartialEsc = false;
         for (int k = m_ansiBuffer.size() - 1; k >= lastProcessed; --k) {
             if (m_ansiBuffer[k] == '\x1B') {
@@ -193,10 +222,10 @@ void TerminalWidget::processData(const QByteArray &data) {
         }
         
         if (!inPartialEsc) {
-            QString text = QString::fromUtf8(m_ansiBuffer.mid(lastProcessed));
-            cursor.insertText(text, currentFormat);
+            flushText(lastProcessed, m_ansiBuffer.size());
             m_ansiBuffer.clear();
         } else {
+            
             m_ansiBuffer = m_ansiBuffer.mid(lastProcessed);
         }
     } else {
@@ -204,6 +233,8 @@ void TerminalWidget::processData(const QByteArray &data) {
     }
     
     verticalScrollBar()->setValue(verticalScrollBar()->maximum());
+    setTextCursor(cursor);
+    ensureCursorVisible();
 }
 
 void TerminalWidget::appendAnsiText(const QString &text) {

--- a/src/terminal/terminal_widget.cpp
+++ b/src/terminal/terminal_widget.cpp
@@ -47,7 +47,10 @@ TerminalWidget::TerminalWidget(QWidget *parent, const QString &workingDirectory)
             this, &TerminalWidget::setWorkingDirectory);
 
     QStringList args;
-    // Shell will be interactive naturally due to PTY, -i is often redundant and can cause duplicate prompts
+    // Use login shell to ensure environment is correctly initialized (common issue on WSL)
+    if (m_shell.contains("sh") || m_shell.contains("zsh")) {
+        args << "-l";
+    }
     
     if (!m_pty->start(m_shell, args, m_workingDirectory)) {
         appendPlainText("Error: Could not start shell: " + m_shell);
@@ -331,6 +334,9 @@ void TerminalWidget::restartShell() {
     }
     
     QStringList args;
+    if (m_shell.contains("sh") || m_shell.contains("zsh")) {
+        args << "-l";
+    }
     
     m_pty->start(m_shell, args, m_workingDirectory);
 }

--- a/src/terminal/terminal_widget.cpp
+++ b/src/terminal/terminal_widget.cpp
@@ -19,6 +19,10 @@ namespace Terminal {
 TerminalWidget::TerminalWidget(QWidget *parent, const QString &workingDirectory)
     : QPlainTextEdit(parent), m_workingDirectory(workingDirectory) {
     
+    if (m_workingDirectory.isEmpty()) {
+        m_workingDirectory = Core::ProjectManager::instance().projectRoot();
+    }
+    
     m_shell = detectShell();
     
     m_restartButton = new QPushButton("New Terminal Session?", this);
@@ -57,7 +61,16 @@ TerminalWidget::~TerminalWidget() {
 }
 
 void TerminalWidget::setWorkingDirectory(const QString &dir) {
+    if (m_workingDirectory == dir) return;
     m_workingDirectory = dir;
+
+    if (m_pty && m_pty->isRunning()) {
+#ifdef Q_OS_WIN
+        sendInput(QString("cd /d \"%1\"\r\n").arg(m_workingDirectory));
+#else
+        sendInput(QString("cd \"%1\"\n").arg(m_workingDirectory));
+#endif
+    }
 }
 
 void TerminalWidget::sendInput(const QString &input) {

--- a/src/terminal/terminal_widget.cpp
+++ b/src/terminal/terminal_widget.cpp
@@ -306,17 +306,11 @@ void TerminalWidget::updateTheme() {
 
 QString TerminalWidget::detectShell() {
 #ifdef Q_OS_WIN
-    char* comspec = getenv("COMSPEC");
-    if (comspec) return QString::fromLocal8Bit(comspec);
     return "cmd.exe";
-#else
-    char* shell = getenv("SHELL");
-    if (shell) return QString::fromLocal8Bit(shell);
-#ifdef Q_OS_MAC
+#elif defined(Q_OS_MAC)
     return "/bin/zsh";
 #else
     return "/bin/bash";
-#endif
 #endif
 }
 

--- a/src/terminal/terminal_widget.h
+++ b/src/terminal/terminal_widget.h
@@ -39,11 +39,13 @@ protected:
     bool event(QEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
     void focusInEvent(QFocusEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
     void insertFromMimeData(const QMimeData *source) override;
 
 private:
     void processData(const QByteArray &data);
     QString detectShell();
+    void moveCursorToEnd();
 
     PtyProcess *m_pty;
     QString m_shell;

--- a/src/terminal/terminal_widget.h
+++ b/src/terminal/terminal_widget.h
@@ -4,10 +4,13 @@
 #include <QPlainTextEdit>
 #include <QProcess>
 #include <QByteArray>
+#include <QFocusEvent>
 
 class QPushButton;
 
 namespace Terminal {
+
+class PtyProcess;
 
 class TerminalWidget : public QPlainTextEdit {
     Q_OBJECT
@@ -28,25 +31,27 @@ signals:
     void outputReceived(const QString &data);
 
 private slots:
-    void onReadyReadStandardOutput();
-    void onReadyReadStandardError();
-    void onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
+    void onProcessFinished(int exitCode);
     void restartShell();
 
 protected:
     void keyPressEvent(QKeyEvent *event) override;
     bool event(QEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
+    void focusInEvent(QFocusEvent *event) override;
+    void insertFromMimeData(const QMimeData *source) override;
 
 private:
     void processData(const QByteArray &data);
     QString detectShell();
 
-    QProcess *m_process;
+    PtyProcess *m_pty;
     QString m_shell;
     QString m_workingDirectory;
     QByteArray m_ansiBuffer;
     QPushButton *m_restartButton;
+    int m_lastCols = -1;
+    int m_lastRows = -1;
 };
 
 } 


### PR DESCRIPTION
0.1.1: The first patch for CodePlace Editor.

This patch brings:
- A fix for cases in which users did not use the default interactive shell. This now uses ```bash``` on Linux, ```zsh``` on Mac, and ```cmd.exe``` on Windows. This involved a hefty refactor of how we handle shells. Instead of using QProcess for piping directly to a shell, we are using ```forkpty``` on Linux/Mac OS, and using ```ConPTY``` on Windows.
- A fix for the View -> Appearance submenu. Previously, we were not properly detecting a widget's visible state properly due to widgets being inside of a dock.

- Added toggle for status bar in "View -> Appearance"
- Added full screen support in "View" (F11 by default)